### PR TITLE
Fix queries

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -31,13 +31,12 @@ export default Route.extend({
 
     const repoFetches = orgs.map((org) => {
       return fetch(`https://api.github.com/search/repositories\?q\=user:${org.id}+archived:false`, {
-        mode: 'no-cors',
         headers: {
           'Authorization': `token ${get(this, 'githubSession.githubAccessToken')}`,
         },
       })
       .then((response) => response.json())
-      .then((repos) => this.store.pushPayload('github-repository', { githubRepository: repos.data.items }));
+      .then((repos) => this.store.pushPayload('github-repository', { githubRepository: repos.items }));
     });
 
     await all(repoFetches);


### PR DESCRIPTION
- we were not capturing all the work being done because the search for repos was only returning the first page (30) of repos per org so some repos/PRs were being excluded entirely
- we were also searching for too much data for this use case (we don't need to search for the repos if we're only interested in PRs)
- this refactors the queries to use the github search api directly rather than through ember-data-github so that we can filter with custom parameters, including only fetching PRs in an org for the last week
- we should no longer hit api rate limiting with these changes