### PR TITLE
Filter more bots

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -20,10 +20,11 @@ export default Controller.extend({
       let users = await all(mergedPulls.map((pull) => pull.get('user')));
       let userLinks = users
         .uniq()
-        .reject((user) => user.get('login') === 'dependabot[bot]')
+        .reject((user) => user.get('login').includes('[bot]'))
         .map((user) => {
         return `<a href="${user.get('htmlUrl')}" target="gh-user">@${user.get('login')}</a>`;
       }).join(', ');
+
       document.querySelector('.fetch-contributors').click();
       this.set('conListUniq', userLinks);
     },


### PR DESCRIPTION
- while the filter for bots was catching depandabot there are others that were making it through
- since it appears that github attaches the string `[bot]` to a user's login on a PR when it is a bot, we can filter more generally for this string and capture more instances of bots
Closes: #11