### PR TITLE
Allow main container to stretch to full browser height

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,9 +1,10 @@
-body {
-  background-color: #efefef;
+html {
+  height: 100%;
 }
 
-.full-height {
-  height: 100vh;
+body {
+  background-color: #efefef;
+  min-height: 100%;
 }
 
 .spinner {

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -1,4 +1,4 @@
-<div class="full-height">
+<div>
   <img
     class="spinner"
     src="assets/img/loading_spinner.gif"


### PR DESCRIPTION
This PR addresses https://github.com/ember-learn/whats-new-in-emberland/issues/59.

I tried a couple of different CSS permutations, and landed on one that worked both for desktop and mobile browser. Additionally I removed the unnecessary `.full-height` for the loader.