### PR TITLE
feat: add contrib avatars

### DIFF
--- a/app/controllers/pull-requests.js
+++ b/app/controllers/pull-requests.js
@@ -82,10 +82,10 @@ export default class PullRequestsController extends Controller {
         displayName = handle;
       }
 
-      return `<span><img src="${avatarUrl}" alt="${displayName}"/><a href="${profileLink}" rel="noopener noreferrer" target="_blank">${displayName}</a></span>`;
+      return `<span style="display: grid; grid-template-columns: 1fr 3fr; grid-gap: 0.75em;"><img src="${avatarUrl}" alt="${displayName}" style="border-radius: 0.5em; border: 1px solid #00000010;"/><div><a href="${profileLink}" rel="noopener noreferrer" target="_blank">${displayName}<br>(${handle})</a></div></span>`;
     });
 
-    this.contributorsList = `<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(64px, 1fr)); grid-gap: 1em; word-break: break-word;">
+    this.contributorsList = `<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(172px, 1fr)); grid-gap: 1em;">
       ${contributorsList.join('\n')}
     </div>`;
   }

--- a/app/controllers/pull-requests.js
+++ b/app/controllers/pull-requests.js
@@ -77,7 +77,7 @@ export default class PullRequestsController extends Controller {
       let displayName;
 
       if (name) {
-        displayName = `${name} (${handle})`;
+        displayName = name;
       } else {
         displayName = handle;
       }

--- a/app/controllers/pull-requests.js
+++ b/app/controllers/pull-requests.js
@@ -85,7 +85,7 @@ export default class PullRequestsController extends Controller {
       return `<a href="${profileLink}" rel="noopener noreferrer" target="_blank"><img src="${avatarUrl}" alt="${displayName}"/>${displayName}</a>`;
     });
 
-    this.contributorsList = `<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); grid-gap: 1em; word-break: break-word;">
+    this.contributorsList = `<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(64px, 1fr)); grid-gap: 1em; word-break: break-word;">
       ${contributorsList.join('\n')}
     </div>`;
   }

--- a/app/controllers/pull-requests.js
+++ b/app/controllers/pull-requests.js
@@ -82,7 +82,7 @@ export default class PullRequestsController extends Controller {
         displayName = handle;
       }
 
-      return `<a href="${profileLink}" rel="noopener noreferrer" target="_blank"><img src="${avatarUrl}" alt="${displayName}"/>${displayName}</a>`;
+      return `<span><img src="${avatarUrl}" alt="${displayName}"/><a href="${profileLink}" rel="noopener noreferrer" target="_blank">${displayName}</a></span>`;
     });
 
     this.contributorsList = `<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(64px, 1fr)); grid-gap: 1em; word-break: break-word;">

--- a/app/templates/pull-requests.hbs
+++ b/app/templates/pull-requests.hbs
@@ -14,6 +14,11 @@
         {{this.contributorsList}}
       </CopyMe>
     </div>
+
+    <div>Rendered</div>
+    <div class="contributors-list-container">
+      {{this.contributorsListRendered}}
+    </div>
   {{/if}}
 </section>
 


### PR DESCRIPTION
This PR is a proposal to add avatars of contributors when mentioning them in the Ember Times.

Why?

- Currently the section is quite the large orange blob due to all the links, making it hard to read through
- Ember is driven by the community, making giving credit an important part of the working
- ...
- Profit?

Here's a quick photoshop of what the rendered output of this app would look like in the Ember Times. It's a copy paste, so the default styling of the links will be the orange styling in the actual app.
![contribs](https://github.com/ember-learn/whats-new-in-emberland/assets/10243652/8885e0c5-464f-49e9-ab97-afb4cbfc51d0)
